### PR TITLE
Diminution de la marge gauche du logo, affichage sur France Relance

### DIFF
--- a/src/components/LeftCol.vue
+++ b/src/components/LeftCol.vue
@@ -237,7 +237,7 @@ export default {
       right: 10px;
     }
     :not(.position-absolute) {
-      margin-left: 15%;
+      margin-left: 3%;
     }
   }
 


### PR DESCRIPTION
En affichage grand écran, le logo est tronqué sur la droite en production, sur le site https://www.economie.gouv.fr/plan-de-relance/tableau-de-bord. Ceci est du à l'intégration des panels dans des iFrame. Pour corriger cet affichage, on propose de réduire la marge gauche du logo.
